### PR TITLE
Refactor salt

### DIFF
--- a/contracts/TreasuryModuleFactory.sol
+++ b/contracts/TreasuryModuleFactory.sol
@@ -24,9 +24,10 @@ contract TreasuryModuleFactory is
     }
 
     /// @dev Creates a Treasury module
+    /// @param creator The address creating the module
     /// @param data The array of bytes used to create the module
     /// @return address[] The array of addresses of the created module
-    function create(bytes[] calldata data)
+    function create(address creator, bytes[] calldata data)
         external
         override
         returns (address[] memory)
@@ -39,7 +40,7 @@ contract TreasuryModuleFactory is
 
         createdContracts[0] = Create2.deploy(
             0,
-            keccak256(abi.encodePacked(tx.origin, block.chainid, salt)),
+            keccak256(abi.encodePacked(creator, msg.sender, block.chainid, salt)),
             abi.encodePacked(
                 type(ERC1967Proxy).creationCode,
                 abi.encode(treasuryImplementation, "")

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@fractal-framework/module-treasury",
       "version": "0.1.0",
       "devDependencies": {
-        "@fractal-framework/core-contracts": "^0.1.4",
+        "@fractal-framework/core-contracts": "^0.1.7",
         "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers@^0.3.0-beta.13",
         "@nomiclabs/hardhat-etherscan": "^3.1.0",
         "@nomiclabs/hardhat-waffle": "^2.0.1",
@@ -1214,9 +1214,9 @@
       }
     },
     "node_modules/@fractal-framework/core-contracts": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@fractal-framework/core-contracts/-/core-contracts-0.1.4.tgz",
-      "integrity": "sha512-eE2jd2rcZSdgJ/ESyfzsVE434W9I4aZ3UdjrkhCryYGj0F7gPKbE+HS2BYPtmbQTmFpDjQgo8YtuJVfVR4Romw==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@fractal-framework/core-contracts/-/core-contracts-0.1.7.tgz",
+      "integrity": "sha512-4VIjkDYsutFqqaJno0+haUcQodO0R6GVdWjoJGrkL6IKeR8byNXOGz1QdpVhxo8o4BK/93e0JcvR220A0pqugg==",
       "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -24482,9 +24482,9 @@
       }
     },
     "@fractal-framework/core-contracts": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@fractal-framework/core-contracts/-/core-contracts-0.1.4.tgz",
-      "integrity": "sha512-eE2jd2rcZSdgJ/ESyfzsVE434W9I4aZ3UdjrkhCryYGj0F7gPKbE+HS2BYPtmbQTmFpDjQgo8YtuJVfVR4Romw==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@fractal-framework/core-contracts/-/core-contracts-0.1.7.tgz",
+      "integrity": "sha512-4VIjkDYsutFqqaJno0+haUcQodO0R6GVdWjoJGrkL6IKeR8byNXOGz1QdpVhxo8o4BK/93e0JcvR220A0pqugg==",
       "dev": true
     },
     "@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "hardhat test"
   },
   "devDependencies": {
-    "@fractal-framework/core-contracts": "^0.1.4",
+    "@fractal-framework/core-contracts": "^0.1.7",
     "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers@^0.3.0-beta.13",
     "@nomiclabs/hardhat-etherscan": "^3.1.0",
     "@nomiclabs/hardhat-waffle": "^2.0.1",

--- a/test/TreasuryFactory.test.ts
+++ b/test/TreasuryFactory.test.ts
@@ -169,8 +169,13 @@ describe("Treasury Factory", function () {
       const predictedTreasury = ethers.utils.getCreate2Address(
         treasuryFactory.address,
         ethers.utils.solidityKeccak256(
-          ["address", "uint256", "bytes32"],
-          [deployer.address, chainId, ethers.utils.formatBytes32String("hi")]
+          ["address", "address", "uint256", "bytes32"],
+          [
+            deployer.address,
+            deployer.address,
+            chainId,
+            ethers.utils.formatBytes32String("hi"),
+          ]
         ),
         ethers.utils.solidityKeccak256(
           ["bytes", "bytes"],

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -1,6 +1,6 @@
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { TreasuryModule, TreasuryModuleFactory } from "../../typechain-types";
-import { BigNumber, ContractReceipt, ContractTransaction, utils } from "ethers";
+import { BigNumber, ContractReceipt, ContractTransaction } from "ethers";
 import { ethers } from "hardhat";
 
 export type TreasuryEthDepositedEvent = {
@@ -54,7 +54,7 @@ export async function createTreasuryFromFactory(
 
   const tx: ContractTransaction = await treasuryFactory
     .connect(caller)
-    .create(data);
+    .create(caller.address, data);
 
   const receipt: ContractReceipt = await tx.wait();
 


### PR DESCRIPTION
This PR:
 - Updates the fractal core contracts package version to 0.1.7
 - Updates the factory contract to use creator and msg.sender for salt instead of tx.origin